### PR TITLE
feat: sort matching systems to the top

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "ink": "^3.0.8",
-    "react": "^17.0.2"
+    "react": "^17.0.2",
+    "systeminformation": "^5.6.12"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 dependencies:
   ink: 3.0.8_@types+react@17.0.3+react@17.0.2
   react: 17.0.2
+  systeminformation: 5.6.12
 devDependencies:
   '@types/jest': 26.0.22
   '@types/node': 14.14.37
@@ -4673,6 +4674,21 @@ packages:
     dev: true
     resolution:
       integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+  /systeminformation/5.6.12:
+    dev: false
+    engines:
+      node: '>=4.0.0'
+    hasBin: true
+    os:
+      - darwin
+      - linux
+      - win32
+      - freebsd
+      - openbsd
+      - netbsd
+      - sunos
+    resolution:
+      integrity: sha512-prJAt+iS2ITeygjLt/FGtN1qsIQHrRePCUqWtP0hGv6JsS0LSQTR+y5hWAd4frUIM/sjG95jHFUK1gx244KwUA==
   /table/6.1.0:
     dependencies:
       ajv: 8.1.0
@@ -5201,5 +5217,6 @@ specifiers:
   prettier: ^2.2.1
   react: ^17.0.2
   strip-ansi: '6'
+  systeminformation: ^5.6.12
   ts-jest: ^26.5.4
   typescript: ^4.2.4

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -23,6 +23,7 @@ test('shows the selected snapshot', async () => {
       path: '/media/ubuntu/2021.04.17-abcdef0123-bmd.iso.gz',
       machineType: 'bmd',
       codeVersion: '2021.04.17-abcdef0123',
+      preferred: false,
     },
   ])
 

--- a/src/components/SnapshotLabel.test.tsx
+++ b/src/components/SnapshotLabel.test.tsx
@@ -10,6 +10,7 @@ test('displays the machine type and code version', () => {
         path: '/media/ubuntu/2021.04.17-abcdef0123-bmd.iso.gz',
         machineType: 'bmd',
         codeVersion: '2021.04.17-abcdef0123',
+        preferred: false,
       }}
     />
   )
@@ -27,6 +28,7 @@ test('displays the code tag if present', () => {
         machineType: 'bmd',
         codeVersion: '2021.04.17-abcdef0123',
         codeTag: 'm11',
+        preferred: false,
       }}
     />
   )

--- a/src/screens/SelectSnapshotScreen.test.tsx
+++ b/src/screens/SelectSnapshotScreen.test.tsx
@@ -44,12 +44,14 @@ test('shows a prompt to select one of the loaded snapshots', async () => {
         '/media/usb-drive/snapshots/2021.04.19-abcdef0123-election-manager.iso.gz',
       machineType: 'election-manager',
       codeVersion: '2021.04.19-abcdef0123',
+      preferred: false,
     },
     {
       path:
         '/media/usb-drive/snapshots/2021.04.19-abcdef0123-ballot-scanner.iso.gz',
       machineType: 'ballot-scanner',
       codeVersion: '2021.04.19-abcdef0123',
+      preferred: false,
     },
   ])
 
@@ -73,5 +75,6 @@ test('shows a prompt to select one of the loaded snapshots', async () => {
       '/media/usb-drive/snapshots/2021.04.19-abcdef0123-election-manager.iso.gz',
     machineType: 'election-manager',
     codeVersion: '2021.04.19-abcdef0123',
+    preferred: false,
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface Snapshot {
   machineType: MachineType
   codeVersion: string
   codeTag?: string
+  preferred: boolean
 }
 
 export type NonEmptyArray<T> = readonly [T, ...T[]]

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,26 @@
 import delay from 'delay'
+import { Systeminformation } from 'systeminformation'
 
 export async function waitForHooks(): Promise<void> {
   await delay(0)
+}
+
+export function fakeSystem({
+  manufacturer = 'jest',
+  model = 'test',
+  version = 'jest test environment',
+  serial = '',
+  sku = '',
+  uuid = '',
+  virtual = true,
+}: Partial<Systeminformation.SystemData> = {}): Systeminformation.SystemData {
+  return {
+    manufacturer,
+    model,
+    version,
+    serial,
+    sku,
+    uuid,
+    virtual,
+  }
 }


### PR DESCRIPTION
When installing on hardware used for a BMD, it'll sort the BMD snapshots to the top.