### PR TITLE
fix: ensure sub-sorting by code version works

### DIFF
--- a/src/lib/snapshots.ts
+++ b/src/lib/snapshots.ts
@@ -29,7 +29,9 @@ function compareMachineTypes(
   b: MachineType,
   systemMachineType?: MachineType
 ): number {
-  if (a === systemMachineType) {
+  if (a === b) {
+    return 0
+  } else if (a === systemMachineType) {
     return -1
   } else if (b === systemMachineType) {
     return 1


### PR DESCRIPTION
When two snapshots have the same machine type, ensure we fall back to sub-sorting by code version.